### PR TITLE
Add ASIO_ENABLE_OLD_SERVICES definition to scout_base_node

### DIFF
--- a/scout_base/CMakeLists.txt
+++ b/scout_base/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories(scout_messenger INTERFACE
 
 add_executable(scout_base_node src/scout_base_node.cpp)
 target_link_libraries(scout_base_node scout_messenger ${catkin_LIBRARIES})
+target_compile_definitions(scout_base_node PUBLIC ASIO_ENABLE_OLD_SERVICES)
 
 #############
 ## Install ##


### PR DESCRIPTION
Building `ugv_sdk` and `scout_base` in isolation (with `catkin_make_isolated`/`catkin build`) fails for me.


The `ASIO_ENABLE_OLD_SERVICES` compile definition is not exported for the `ugv_sdk` target.

It is needed when including `ugv_sdk/include/ugv_sdk/details/async_port/async_can.hpp`.